### PR TITLE
Check for known android key hashes

### DIFF
--- a/src/WebAuthn.php
+++ b/src/WebAuthn.php
@@ -30,6 +30,7 @@ class WebAuthn {
     private $_signatureCounter;
     private $_caFiles;
     private $_formats;
+    private $_androidKeyHashes;
 
     /**
      * Initialize a new WebAuthn server
@@ -87,6 +88,23 @@ class WebAuthn {
             }
         } else if (\is_file($path) && !\in_array(\realpath($path), $this->_caFiles)) {
             $this->_caFiles[] = \realpath($path);
+        }
+    }
+
+    /**
+     * add key hashes for android verification
+     * @param array<string> $hashes
+     * @return void
+     */
+    public function addAndroidKeyHashes($hashes) {
+        if (!\is_array($this->_androidKeyHashes)) {
+            $this->_androidKeyHashes = [];
+        }
+
+        foreach ($hashes as $hash) {
+            if (is_string($hash)) {
+                $this->_androidKeyHashes[] = $hash;
+            }
         }
     }
 
@@ -603,6 +621,10 @@ class WebAuthn {
      * @throws WebAuthnException
      */
     private function _checkOrigin($origin) {
+        if (str_starts_with('android:apk-key-hash:', $origin)) {
+            return $this->_checkAndroidKeyHashes($origin);
+        }
+
         // https://www.w3.org/TR/webauthn/#rp-id
 
         // The origin's scheme must be https
@@ -617,6 +639,19 @@ class WebAuthn {
         // The RP ID must be equal to the origin's effective domain, or a registrable
         // domain suffix of the origin's effective domain.
         return \preg_match('/' . \preg_quote($this->_rpId) . '$/i', $host) === 1;
+    }
+
+    /**
+     * checks if the origin value contains a known android key hash
+     * @param string $origin
+     * @return boolean
+     */
+    private function _checkAndroidKeyHashes($origin) {
+        $parts = explode('android:apk-key-hash:', $origin);
+        if (count($parts) !== 2) {
+            return false;
+        }
+        return in_array($parts[1], $this->_androidKeyHashes, true);
     }
 
     /**


### PR DESCRIPTION
If the origin starts with android `:apk-key-hash:`, it will check for the allowed/known android key hashes instead of checking the expected origin URL for the RP ID